### PR TITLE
Apache template and attribute to lock down CFIDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ The following attributes are under `node['cf10']['apache']`:
 * `['ssl_cert_key_file']` - The SSL key to use for Apache (default: "/etc/ssl/private/ssl-cert-snakeoil.key")
 * `['ssl_cert_chain_file']` - The SSL chain to use for Apache (default: nil) 
 * `['adminapi_whitelist']` - An array of hosts/IP addresses beyond localhost/127.0.0.1 to grant adminapi access.
+* `['cfide_whitelist']` - An array of hosts/IP addresses beyond localhost/127.0.0.1 and `adminapi_whitelist` to grant CFIDE access.
 
 For Chef Search
 ---------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,9 @@ default['cf10']['apache']['ssl_cert_chain_file'] = nil
 # Lock down /CFIDE/adminapi
 default['cf10']['apache']['adminapi_whitelist'] = []
 
+# Lock down /CFIDE
+default['cf10']['apache']['cfide_whitelist'] = node['cf10']['apache']['adminapi_whitelist']
+
 # Configuration 
 default['cf10']['config_settings'] = {}
 

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -38,6 +38,16 @@ template "#{node['apache']['dir']}/conf.d/adminapi.conf" do
   notifies :restart, "service[apache2]", :delayed
 end
 
+# Lock down CFIDE
+
+template "#{node['apache']['dir']}/conf.d/cfide.conf" do
+  source "cfide.conf.erb"
+  owner node['apache']['user']
+  group node['apache']['group']
+  mode 00644
+  notifies :restart, "service[apache2]", :delayed
+end
+
 # Make sure CF is running
 execute "start_cf_for_coldfusion10_wsconfig" do
   command "/bin/true"

--- a/templates/default/cfide.conf.erb
+++ b/templates/default/cfide.conf.erb
@@ -1,0 +1,29 @@
+  <Directory "<%= node['cf10']['installer']['install_folder']%>/cfusion/wwwroot/CFIDE">
+      Order deny,allow
+      Deny from all
+      Allow from localhost
+      Allow from 127.0.0.1
+      <% node['cf10']['apache']['cfide_whitelist'].each do |host| %>
+      Allow from <%= host%>
+      <% end %>
+  </Directory>
+
+  <Location "/CFIDE">
+      Order deny,allow
+      Deny from all
+      Allow from localhost
+      Allow from 127.0.0.1
+      <% node['cf10']['apache']['cfide_whitelist'].each do |host| %>
+      Allow from <%= host%>
+      <% end %>
+  </Location>
+
+  <Location "/cfide">
+      Order deny,allow
+      Deny from all
+      Allow from localhost
+      Allow from 127.0.0.1
+      <% node['cf10']['apache']['cfide_whitelist'].each do |host| %>
+      Allow from <%= host%>
+      <% end %>
+  </Location>


### PR DESCRIPTION
Should we add something like this to protect the entirety of CFIDE?
