### PR TITLE
Added debian specific directives.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,6 +113,8 @@ default['cf10']['updates']['urls'] = %w{
   http://download.adobe.com/pub/adobe/coldfusion/hotfix_009.jar
   http://download.adobe.com/pub/adobe/coldfusion/hotfix_010.jar
   http://download.adobe.com/pub/adobe/coldfusion/hotfix_011.jar
+  http://download.adobe.com/pub/adobe/coldfusion/hotfix_012.jar
+  http://download.adobe.com/pub/adobe/coldfusion/hotfix_013.jar
 }
 default['cf10']['updates']['files'] = %w{ 
   hf1000-3332326.jar
@@ -126,6 +128,8 @@ default['cf10']['updates']['files'] = %w{
   chf10000009.jar
   chf10000010.jar
   chf10000011.jar
+  chf10000012.jar
+  chf10000013.jar
 }
 
 # Tomcat or Apache web root

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "nmische@gmail.com"
 license          "Apache 2.0"
 description      "Installs/Configures Adobe ColdFusion 10"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.4.10"
+version          "0.4.11"
 
 %w{ centos redhat ubuntu }.each do |os|
   supports os

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -48,6 +48,13 @@ execute "install_wsconfig" do
       cp -f #{node['apache']['dir']}/conf/mod_jk.conf #{node['apache']['dir']}/conf.d/mod_jk.conf
       sleep 11
       COMMAND
+    when "debian"
+      command <<-COMMAND
+      sleep 11
+      ln -s #{node['apache']['dir']}/apache2.conf #{node['apache']['dir']}/httpd.conf
+      #{node['cf10']['installer']['install_folder']}/cfusion/runtime/bin/wsconfig -ws Apache -dir #{node['apache']['dir']} -bin #{node['apache']['binary']} -script /usr/sbin/apache2ctl -v
+      sleep 11
+      COMMAND
     else
       command <<-COMMAND
       sleep 11
@@ -70,6 +77,13 @@ execute "uninstall_wsconfig" do
       #{node['cf10']['installer']['install_folder']}/cfusion/runtime/bin/wsconfig -uninstall -bin #{node['apache']['binary']} -script /usr/sbin/apachectl -v
       rm -f #{node['apache']['dir']}/conf/httpd.conf.1 
       rm -f #{node['apache']['dir']}/conf.d/mod_jk.conf
+      sleep 11
+      COMMAND
+    when "debian"
+      command <<-COMMAND
+      sleep 11
+      #{node['cf10']['installer']['install_folder']}/cfusion/runtime/bin/wsconfig -uninstall -bin #{node['apache']['binary']} -script /usr/sbin/apache2ctl -v
+      rm -f #{node['apache']['dir']}/httpd.conf
       sleep 11
       COMMAND
     else


### PR DESCRIPTION
wsconfig is looking for a file called httpd.conf. On the latest debian versions (6 and 7) this file is called apache2.conf. To fix this problem a symlink will be created pointing to the apache2.conf.
